### PR TITLE
Fix for "width" property setting to "0px" on some videos

### DIFF
--- a/UncompressedImages.plugin.js
+++ b/UncompressedImages.plugin.js
@@ -62,7 +62,8 @@ start() {
 			const imgElement = imgElements[index];
 			if (!imgElement.classList.contains("max-width-adjusted")) {
 			  const style = window.getComputedStyle(imgElement);
-			  const currentWidth = style.getPropertyValue('width');
+			  let currentWidth = style.getPropertyValue('width');
+			  if (currentWidth === "0px") currentWidth = "auto";	
 			  imgElement.style.maxWidth = currentWidth;
 			  imgElement.classList.add("max-width-adjusted");
 			  /** console.log(`Adjusted max-width for image to ${currentWidth}`); **/


### PR DESCRIPTION
For some videos, when entering fullscreen, after a short while the "width" property is being set to "0px".

I couldn't find the root cause of this issue, disabled all but this plugin and I could repeatedly recreate the issue for the original video, but not when copying the video link to another server.
If you want to check out the shown video for testing, shoot me a DM on Discord @htky .

Without fix:
https://streamable.com/tyefrm

With fix:
https://streamable.com/gakf76